### PR TITLE
Add standalone launcher and smarter data-dir defaults; update config and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,29 @@ The subpath route uses Traefik's `StripPrefix` middleware which sets `X-Forwarde
 docker exec cae-dashboard ./scripts/cae-collect
 ```
 
+## Run standalone (without Docker)
+
+You can run Prumo directly on your machine with Python:
+
+```bash
+./scripts/run-standalone
+```
+
+This launcher will:
+- create `.venv` automatically (if missing),
+- install `requirements.txt`,
+- default data paths to `./data` when `/data` is not available.
+
+Optional overrides:
+
+```bash
+CAE_DATA_DIR=./data \
+CAE_DB_PATH=./data/cae-data.duckdb \
+ANALYTICS_DB_PATH=./data/analytics.db \
+CAE_PORT=8080 \
+./scripts/run-standalone
+```
+
 ## Technical Notes
 
 - **Single worker**: Uvicorn runs with `--workers 1` because DuckDB connections are not thread-safe. FastAPI's thread pool handles concurrent requests via per-thread connection reuse.

--- a/app/config.py
+++ b/app/config.py
@@ -1,10 +1,26 @@
 import json
 import os
 
-# ── Site config: /data/site.json (editable without rebuild) ──────────
+
+def _default_data_dir() -> str:
+    """Pick a writable data directory for non-container runs.
+
+    Preference order:
+    1) CAE_DATA_DIR env var
+    2) /data (container default)
+    3) <repo>/data (local standalone default)
+    """
+    if os.environ.get("CAE_DATA_DIR"):
+        return os.environ["CAE_DATA_DIR"]
+    if os.path.isdir("/data"):
+        return "/data"
+    return os.path.join(os.path.dirname(os.path.dirname(__file__)), "data")
+
+# ── Site config (editable without rebuild) ────────────────────────────
 # Loaded first so paths.db can override CAE_DB_PATH default.
-_DATA_DIR_DEFAULT = os.environ.get("CAE_DB_PATH", "/data/cae-data.duckdb")
-_SITE_CONFIG_PATH = os.path.join(os.path.dirname(_DATA_DIR_DEFAULT), "site.json")
+_CAE_DB_PATH_ENV = os.environ.get("CAE_DB_PATH")
+_DATA_DIR_DEFAULT = os.path.dirname(_CAE_DB_PATH_ENV) if _CAE_DB_PATH_ENV else _default_data_dir()
+_SITE_CONFIG_PATH = os.path.join(_DATA_DIR_DEFAULT, "site.json")
 _SITE_CFG = {}
 try:
     if os.path.exists(_SITE_CONFIG_PATH):
@@ -25,9 +41,9 @@ def site_cfg(key: str, default=None):
 
 
 # ── Paths (site.json > env var > default) ────────────────────────────
-CAE_DB_PATH = _paths.get("db") or os.environ.get("CAE_DB_PATH", "/data/cae-data.duckdb")
+CAE_DB_PATH = _paths.get("db") or _CAE_DB_PATH_ENV or os.path.join(_DATA_DIR_DEFAULT, "cae-data.duckdb")
 ENERGY_DB_PATH = os.path.join(os.path.dirname(CAE_DB_PATH), "energy-data.db")
-ANALYTICS_DB_PATH = _paths.get("analytics_db") or os.environ.get("ANALYTICS_DB_PATH", "/data/analytics.db")
+ANALYTICS_DB_PATH = _paths.get("analytics_db") or os.environ.get("ANALYTICS_DB_PATH") or os.path.join(_DATA_DIR_DEFAULT, "analytics.db")
 IDEOLOGIES_DIR = _paths.get("ideologies_dir") or os.path.join(os.path.dirname(CAE_DB_PATH), "ideologies")
 INTERPRET_CACHE_PATH = _paths.get("interpret_cache") or os.path.join(os.path.dirname(CAE_DB_PATH), "interpret-cache.json")
 PAINEL_CACHE_PATH = _paths.get("painel_cache") or os.path.join(os.path.dirname(CAE_DB_PATH), "painel-analysis-cache.json")

--- a/scripts/run-standalone
+++ b/scripts/run-standalone
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+VENV_DIR="${VENV_DIR:-.venv}"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+VENV_PYTHON="$VENV_DIR/bin/python"
+if [[ ! -x "$VENV_PYTHON" ]]; then
+  echo "Virtual environment python not found: $VENV_PYTHON" >&2
+  exit 1
+fi
+
+if ! "$VENV_PYTHON" -c "import fastapi, uvicorn, jinja2, duckdb, pandas" >/dev/null 2>&1; then
+  "$VENV_PYTHON" -m ensurepip --upgrade >/dev/null 2>&1 || true
+  if ! "$VENV_PYTHON" -m pip install -r requirements.txt >/dev/null; then
+    echo "Warning: failed to install dependencies in $VENV_DIR; falling back to current Python environment." >&2
+    VENV_PYTHON="${PYTHON_BIN}"
+  fi
+fi
+
+export CAE_DATA_DIR="${CAE_DATA_DIR:-$ROOT_DIR/data}"
+export CAE_DB_PATH="${CAE_DB_PATH:-$CAE_DATA_DIR/cae-data.duckdb}"
+export ANALYTICS_DB_PATH="${ANALYTICS_DB_PATH:-$CAE_DATA_DIR/analytics.db}"
+export CAE_PORT="${CAE_PORT:-8080}"
+
+mkdir -p "$CAE_DATA_DIR"
+
+cat <<MSG
+Starting Prumo (standalone mode)
+  CAE_DB_PATH=$CAE_DB_PATH
+  ANALYTICS_DB_PATH=$ANALYTICS_DB_PATH
+  URL=http://127.0.0.1:$CAE_PORT
+MSG
+
+exec "$VENV_PYTHON" -m uvicorn app.main:app --host 127.0.0.1 --port "$CAE_PORT"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,64 @@
+import importlib
+import os
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _reload_config(monkeypatch, env):
+    """Reload app.config after applying environment overrides."""
+    keys = [
+        "CAE_DATA_DIR",
+        "CAE_DB_PATH",
+        "ANALYTICS_DB_PATH",
+        "CAE_PORT",
+    ]
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    sys.modules.pop("app.config", None)
+    import app.config as config
+
+    return importlib.reload(config)
+
+
+def test_defaults_to_repo_data_dir_when_no_env_and_no_data_mount(monkeypatch):
+    monkeypatch.setattr(os.path, "isdir", lambda p: False if p == "/data" else os.path.isdir(p))
+
+    config = _reload_config(monkeypatch, {})
+
+    expected = REPO_ROOT / "data"
+    assert Path(config.CAE_DB_PATH) == expected / "cae-data.duckdb"
+    assert Path(config.ANALYTICS_DB_PATH) == expected / "analytics.db"
+
+
+def test_uses_cae_data_dir_for_default_paths(monkeypatch, tmp_path):
+    data_dir = tmp_path / "custom-data"
+
+    config = _reload_config(monkeypatch, {"CAE_DATA_DIR": str(data_dir)})
+
+    assert Path(config.CAE_DB_PATH) == data_dir / "cae-data.duckdb"
+    assert Path(config.ANALYTICS_DB_PATH) == data_dir / "analytics.db"
+
+
+def test_explicit_db_env_vars_take_precedence(monkeypatch, tmp_path):
+    cae_db = tmp_path / "db" / "main.duckdb"
+    analytics_db = tmp_path / "db" / "analytics.duckdb"
+
+    config = _reload_config(
+        monkeypatch,
+        {
+            "CAE_DATA_DIR": str(tmp_path / "ignored"),
+            "CAE_DB_PATH": str(cae_db),
+            "ANALYTICS_DB_PATH": str(analytics_db),
+        },
+    )
+
+    assert Path(config.CAE_DB_PATH) == cae_db
+    assert Path(config.ANALYTICS_DB_PATH) == analytics_db


### PR DESCRIPTION
### Motivation

- Allow running the app locally without Docker by picking a writable data directory and providing a simple launcher.
- Make DB and analytics paths deterministic and configurable from `site.json` or environment variables so local and container runs behave correctly.
- Improve developer experience with a one-step `run-standalone` that bootstraps a virtualenv, installs deps and launches the server.

### Description

- Add `_default_data_dir()` to choose `CAE_DATA_DIR`, `/data`, or the repository `data/` directory and use it to compute `_DATA_DIR_DEFAULT` and `_SITE_CONFIG_PATH`.
- Change path resolution so `CAE_DB_PATH` and `ANALYTICS_DB_PATH` prefer `site.json` entries, then explicit env vars, and finally sensible defaults under the selected data dir, and update related path constants accordingly.
- Add `scripts/run-standalone` which creates a `.venv`, installs `requirements.txt` if needed, exports `CAE_*` env vars defaults, and execs `uvicorn app.main:app` for local runs.
- Update `README.md` with a `Run standalone` section describing the launcher and environment overrides, and add `tests/test_config.py` to validate path selection logic.

### Testing

- Ran `pytest tests/test_config.py` and all 3 tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a978853aac832d97c4fe5e98647ab3)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates `app/config.py` path-resolution logic used by DuckDB/analytics connections, which could change where `site.json` and database files are read from in some deployments. Scope is limited and includes tests to validate the new precedence rules.
> 
> **Overview**
> Adds a standalone `./scripts/run-standalone` launcher that bootstraps a local venv (if needed), installs dependencies, sets default `CAE_*` env vars, and starts Uvicorn for running without Docker.
> 
> Refactors `app/config.py` to derive a default data directory (`CAE_DATA_DIR` → `/data` → repo `./data`) and to resolve `CAE_DB_PATH`/`ANALYTICS_DB_PATH` via **`site.json` → explicit env vars → defaults under the selected data dir**; updates README docs accordingly and adds `tests/test_config.py` to lock in the new precedence behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e674c2332b06579a279fa0fa9e95e2c0d911b47c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->